### PR TITLE
Clean up dist directory from previous artifacts

### DIFF
--- a/package/package.sh
+++ b/package/package.sh
@@ -1,3 +1,4 @@
+rm -rf dist
 export DJHEROKU_MINOR_VERSION=`date +%Y%m%d%H%M%S`
 virtualenv -q .venv
 . .venv/bin/activate


### PR DESCRIPTION
The builder generates leftovers if the dist directory is not
cleaned.
