### PR TITLE
Depend on a non-explicit version of mock

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,4 @@ Django>=1.4.1
 nose==1.2.1
 setuptools-lint==0.1
 pylint==0.26.0
-mock==1.0.0
+mock>=1.0.0


### PR DESCRIPTION
There may be dependency issues now that mock 1.0.1 is out
