### PR TITLE
Fix email subject prefix and simplify code

### DIFF
--- a/djheroku/conf.py
+++ b/djheroku/conf.py
@@ -106,13 +106,13 @@ def cloudant():
 
 def identity():
     ''' Maps outgoing email settings and application name to environment '''
-    mapping = {
-                  'SERVER_EMAIL': 'SERVER_EMAIL',
-                  'EMAIL_SUBJECT_PREFIX': 'INSTANCE',
-              }
-    result = env_to_django(mapping)
-    if 'SERVER_EMAIL' not in result:
-        result['SERVER_EMAIL'] = 'root@localhost'
+    result = {}
+        
+    result['SERVER_EMAIL'] = os.environ.get('SERVER_EMAIL', 'root@localhost')
+
+    instance = os.environ.get('INSTANCE')
+    if instance:
+        result['EMAIL_SUBJECT_PREFIX'] = '[{0}] '.format(instance)
 
     admins = [x.split(':') for x in os.environ.get('ADMINS', '').split(',')]
 

--- a/djheroku/tests.py
+++ b/djheroku/tests.py
@@ -334,7 +334,7 @@ class TestDjheroku(unittest2.TestCase):  # pylint: disable=R0904
         ''' Test Django email settings '''
         result = identity()
         self.assertEquals('application@example.com', result['SERVER_EMAIL'])
-        self.assertEquals('djheroku-test', result['EMAIL_SUBJECT_PREFIX'])
+        self.assertEquals('[djheroku-test] ', result['EMAIL_SUBJECT_PREFIX'])
         self.assertIn('ADMINS', result)
         self.assertIn(['Admin', 'admin@example.com'], result['ADMINS'])
         self.assertEquals(2, len(result['ADMINS']))


### PR DESCRIPTION
The email subject prefix would look ugly with the initial version.
Django default is '[Django] ' with a space and brackets, following
that.
