### PR TITLE
Add support for API keys

### DIFF
--- a/djheroku/__init__.py
+++ b/djheroku/__init__.py
@@ -1,2 +1,3 @@
 ''' Djheroku for populating Heroku environment variables to Django '''
-from djheroku.conf import sendgrid, mailgun, cloudant, memcachier, identity
+from djheroku.conf import (sendgrid, mailgun, cloudant, memcachier, identity,
+                           social)

--- a/djheroku/conf.py
+++ b/djheroku/conf.py
@@ -120,3 +120,32 @@ def identity():
         result['ADMINS'] = admins
 
     return result
+
+def social():
+    ''' Maps API keys to Django settings '''
+    result = {}
+    facebook = {}
+    try:
+        facebook['FACEBOOK_APP_ID'] = os.environ['FACEBOOK_ID']
+        facebook['FACEBOOK_SECRET_KEY'] = os.environ['FACEBOOK_SECRET']
+        result.update(facebook)
+    except KeyError:
+        pass
+        
+    twitter = {}
+    try:
+        twitter['TWITTER_CONSUMER_KEY'] = os.environ['TWITTER_ID']
+        twitter['TWITTER_CONSUMER_SECRET_KEY'] = os.environ['TWITTER_SECRET']
+        result.update(twitter)
+    except KeyError:
+        pass
+
+    linkedin = {}
+    try:
+        linkedin['LINKEDIN_CONSUMER_KEY'] = os.environ['LINKEDIN_ID']
+        linkedin['LINKEDIN_CONSUMER_SECRET_KEY'] = os.environ['LINKEDIN_SECRET']
+        result.update(linkedin)
+    except KeyError:
+        pass
+
+    return result

--- a/djheroku/tests.py
+++ b/djheroku/tests.py
@@ -5,7 +5,7 @@ from __future__ import with_statement
 
 import unittest2
 from mock import MagicMock
-from djheroku import sendgrid, mailgun, cloudant, memcachier, identity
+from djheroku import sendgrid, mailgun, cloudant, memcachier, identity, social
 import os
 
 from django.conf import settings
@@ -31,6 +31,12 @@ ENVIRON_DICT = {'SENDGRID_USERNAME': 'alice',
                 'SERVER_EMAIL': 'application@example.com',
                 'INSTANCE': 'djheroku-test',
                 'ADMINS': 'Admin:admin@example.com,Boss:phb@example.com',
+                'FACEBOOK_ID': 'fbapp',
+                'FACEBOOK_SECRET': 'fbsecret',
+                'TWITTER_ID': 'twitkey',
+                'TWITTER_SECRET': 'twithush',
+                'LINKEDIN_ID': 'linkdkey',
+                'LINKEDIN_SECRET': 'linkdhush',
                 }
 
 
@@ -339,3 +345,21 @@ class TestDjheroku(unittest2.TestCase):  # pylint: disable=R0904
         self.assertIn(['Admin', 'admin@example.com'], result['ADMINS'])
         self.assertEquals(2, len(result['ADMINS']))
         self.assertEquals(['Boss', 'phb@example.com'], result['ADMINS'][1])
+
+    def test_social(self):
+        ''' Test API key settings '''
+        result = social()
+        self.assertEquals('fbapp', result['FACEBOOK_APP_ID'])
+        self.assertEquals('fbsecret', result['FACEBOOK_SECRET_KEY'])
+        self.assertEquals('twitkey', result['TWITTER_CONSUMER_KEY'])
+        self.assertEquals('twithush', result['TWITTER_CONSUMER_SECRET_KEY'])
+        self.assertEquals('linkdkey', result['LINKEDIN_CONSUMER_KEY'])
+        self.assertEquals('linkdhush', result['LINKEDIN_CONSUMER_SECRET_KEY'])
+
+        del(ENVIRON_DICT['FACEBOOK_SECRET'])
+        del(ENVIRON_DICT['TWITTER_ID'])
+        result = social()
+        self.assertNotIn('FACEBOOK_APP_ID', result)
+        self.assertNotIn('TWITTER_CONSUMER_SECRET_KEY', result)
+        self.assertIn('LINKEDIN_CONSUMER_KEY', result)
+


### PR DESCRIPTION
Read API keys from environment with the names django-socialregistration
expects. This applies for:
- Twitter
- Facebook
- LinkedIn
