### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,15 +17,15 @@ variables and injects them to Django configuration.
      :target: https://requires.io/github/fubaz/djheroku/requirements/?branch=master
      :alt: Requirements Status
 
-.. image:: https://pypip.in/version/djheroku/badge.svg
+.. image:: https://img.shields.io/pypi/v/djheroku.svg
     :target: https://pypi.python.org/pypi/djheroku/
     :alt: Latest Version
 
-.. image:: https://pypip.in/wheel/djheroku/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/djheroku.svg
     :target: https://pypi.python.org/pypi/djheroku/
     :alt: Wheel Status
 
-.. image:: https://pypip.in/license/djheroku/badge.svg
+.. image:: https://img.shields.io/pypi/l/djheroku.svg
     :target: https://pypi.python.org/pypi/djheroku/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20djheroku))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `djheroku`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.